### PR TITLE
Everbridge alerts

### DIFF
--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
@@ -65,7 +65,8 @@ fun EverbridgeAlert.isForStation(station: Station): Boolean {
         it.variableName.contains("elevator", true)
     }
     return elevatorDesc?.value?.get(0)?.contains(
-        station.displayName.split(" ")[0], false
+        "${station.displayName.split(" ")[0]}|${station.pathApiName}"
+            .toRegex(RegexOption.IGNORE_CASE)
     ) ?: false
 }
 

--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
@@ -64,7 +64,7 @@ fun EverbridgeAlert.isForStation(station: Station): Boolean {
     val elevatorDesc = incidentMessage.formVariableItems.firstOrNull {
         it.variableName.contains("elevator", true)
     }
-    return elevatorDesc?.value?.get(0)?.contains(
+    return elevatorDesc?.value?.firstOrNull()?.contains(
         "${station.displayName.split(" ")[0]}|${station.pathApiName}"
             .toRegex(RegexOption.IGNORE_CASE)
     ) ?: false

--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
@@ -1,0 +1,133 @@
+package com.sixbynine.transit.path.api.everbridge
+
+import com.sixbynine.transit.path.api.Station
+import com.sixbynine.transit.path.api.alerts.Alert
+import com.sixbynine.transit.path.api.alerts.AlertText
+import com.sixbynine.transit.path.api.alerts.Schedule
+import com.sixbynine.transit.path.api.alerts.TrainFilter
+import com.sixbynine.transit.path.time.NewYorkTimeZone
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+private const val PATH_ALERTS_URL = "https://www.panynj.gov/path/en/alerts.html"
+
+@Serializable
+data class EverbridgeAlerts(
+    val data: List<EverbridgeAlert>,
+    val status: String,
+) {
+    constructor(vararg everbridgeAlerts: EverbridgeAlert) : this(
+        everbridgeAlerts.toList(),
+        "success"
+    )
+}
+
+@Serializable
+data class EverbridgeAlert(
+    val incidentMessage: IncidentMessage,
+    @JsonNames("CreatedDate")
+    val createdDate: Long,
+    /** It is suspected that these two dates are the same anyway **/
+    @JsonNames("ModifiedDate")
+    val modifiedDate: Long,
+)
+
+@Serializable
+data class IncidentMessage(
+    /** Title of the alert, usually describes the cause **/
+    val subject: String,
+    /** The full alert message **/
+    val preMessage: String,
+    /** Variables **/
+    val formVariableItems: List<Variable>,
+)
+
+@Serializable
+data class Variable(
+    /** Exact value of each variable. Can be empty **/
+    @JsonNames("val")
+    val value: List<String>? = null,
+    /** Name of the variable **/
+    val variableName: String,
+    /** Whether the information is required; true for those stating the outage, false for guidance **/
+    val isRequired: Boolean,
+    /** Order of variable, increments from 1 **/
+    val seq: Int
+)
+
+fun EverbridgeAlert.isForStation(station: Station): Boolean {
+    val elevatorDesc = incidentMessage.formVariableItems.firstOrNull {
+        it.variableName.contains("elevator", true)
+    }
+    return elevatorDesc?.value?.get(0)?.contains(
+        station.displayName.split(" ")[0], false
+    ) ?: false
+}
+
+fun EverbridgeAlert.isForLines(lineIds: List<Int>): Boolean {
+    // this should match the order in Line.kt
+    val linesDesc = incidentMessage.formVariableItems.firstOrNull { it.variableName == "Lines" }
+    return linesDesc?.value?.any { lineIds.contains(lineToIndex(it)) } ?: false
+}
+
+fun EverbridgeAlert.toGithubAlert(): Alert {
+    return Alert(
+        stations = emptyList(),
+        schedule = Schedule.once(
+            from = Instant.fromEpochMilliseconds(modifiedDate).toLocalDateTime(NewYorkTimeZone),
+            to = Clock.System.now().plus(1.toDuration(DurationUnit.HOURS))
+                .toLocalDateTime(NewYorkTimeZone)
+        ),
+        trains = TrainFilter(),
+        message = AlertText(incidentMessage.preMessage),
+        url = AlertText(PATH_ALERTS_URL),
+        isGlobal = true,
+        level = "WARN"
+    )
+}
+
+fun EverbridgeAlert.toGithubAlert(station: Station): Alert {
+    return Alert(
+        stations = listOf(station),
+        schedule = Schedule.once(
+            from = Instant.fromEpochMilliseconds(modifiedDate).toLocalDateTime(NewYorkTimeZone),
+            to = Clock.System.now().plus(1.toDuration(DurationUnit.HOURS))
+                .toLocalDateTime(NewYorkTimeZone)
+        ),
+        trains = TrainFilter(),
+        message = AlertText(incidentMessage.preMessage),
+        url = AlertText(PATH_ALERTS_URL)
+    )
+}
+
+fun EverbridgeAlerts.getAlertsForStation(station: Station): List<Alert> {
+    return data.filter {
+        it.isForStation(station)
+    }.map {
+        it.toGithubAlert(station)
+    }
+}
+
+fun EverbridgeAlerts.getAlertsForLines(lineIds: List<Int>): List<Alert> {
+    return data.filter {
+        it.isForLines(lineIds)
+    }.map {
+        it.toGithubAlert()
+    }
+}
+
+fun lineToIndex(line: String): Int {
+    when (line) {
+        // TODO: weekend services
+        "NWK-WTC" -> return 1
+        "HOB-WTC" -> return 2
+        "JSQ-33" -> return 3
+        "HOB-33" -> return 4
+    }
+    return 0
+}

--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlertsRepository.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlertsRepository.kt
@@ -1,0 +1,20 @@
+package com.sixbynine.transit.path.api.everbridge
+
+import com.sixbynine.transit.path.util.FetchWithPrevious
+import com.sixbynine.transit.path.util.RemoteFileRepository
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.minutes
+
+object EverbridgeAlertsRepository {
+
+    private val helper = RemoteFileRepository(
+        keyPrefix = "everbridge_alerts",
+        url = "https://panynj.gov/bin/portauthority/everbridge/incidents?status=All&department=Path",
+        serializer = EverbridgeAlerts.serializer(),
+        maxAge = 15.minutes
+    )
+
+    fun getAlerts(now: Instant): FetchWithPrevious<EverbridgeAlerts> {
+        return helper.get(now)
+    }
+}

--- a/api/src/commonTest/kotlin/com/sixbynine/transit/path/EverbridgeAlertsTest.kt
+++ b/api/src/commonTest/kotlin/com/sixbynine/transit/path/EverbridgeAlertsTest.kt
@@ -1,0 +1,168 @@
+package com.sixbynine.transit.path
+
+import com.sixbynine.transit.path.api.Stations
+import com.sixbynine.transit.path.api.alerts.AlertText
+import com.sixbynine.transit.path.api.alerts.isActiveAt
+import com.sixbynine.transit.path.api.everbridge.EverbridgeAlert
+import com.sixbynine.transit.path.api.everbridge.EverbridgeAlerts
+import com.sixbynine.transit.path.api.everbridge.IncidentMessage
+import com.sixbynine.transit.path.api.everbridge.Variable
+import com.sixbynine.transit.path.api.everbridge.getAlertsForLines
+import com.sixbynine.transit.path.api.everbridge.getAlertsForStation
+import com.sixbynine.transit.path.util.JsonFormat
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month.DECEMBER
+import kotlinx.datetime.Month.OCTOBER
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EverbridgeAlertsTest {
+    @Test
+    fun `current alerts text`() {
+        val alerts = EverbridgeAlerts(
+            HobokenElevatorDown,
+            NwkWtcDown
+        )
+
+        val json = JsonFormat.encodeToString(alerts)
+
+        assertEquals(alerts, JsonFormat.decodeFromString(json))
+
+        println(json)
+    }
+
+    @Test
+    fun `station alert conversion`() {
+        val alerts = EverbridgeAlerts(HobokenElevatorDown)
+        val result = alerts.getAlertsForStation(Stations.Hoboken).first()
+        assertEquals(result.stations, listOf(Stations.Hoboken.pathApiName))
+        assertEquals(result.message, AlertText(HobokenElevatorDown.incidentMessage.preMessage))
+        assertNull(result.trains.all)
+        assertNull(result.trains.headSigns)
+        assertTrue(result.isActiveAt(LocalDateTime(2024, DECEMBER, 23, 16, 21)))
+        assertTrue(alerts.getAlertsForStation(Stations.JournalSquare).isEmpty())
+    }
+
+    @Test
+    fun `global alert conversion`() {
+        val alerts = EverbridgeAlerts(NwkWtcDown)
+        val result = alerts.getAlertsForLines(listOf(1)).first()
+        assertEquals(result.stations, emptyList())
+        assertEquals(result.message, AlertText(NwkWtcDown.incidentMessage.preMessage))
+        assertNull(result.trains.all)
+        assertNull(result.trains.headSigns)
+        assertTrue(result.isActiveAt(LocalDateTime(2024, OCTOBER, 21, 13, 57)))
+        assertTrue(result.isGlobal)
+        assertTrue(alerts.getAlertsForLines(listOf(2)).isEmpty())
+    }
+
+    private companion object {
+        val HobokenElevatorDown = EverbridgeAlert(
+            incidentMessage = IncidentMessage(
+                subject = "PATHAlert - Elevators",
+                preMessage = "At Hoboken, elevator from street to fare zone is temporarily out of service. Call 800-234-PATH or use Passenger Assistance Phone if no agent is available. We regret this inconvenience.",
+                formVariableItems = listOf(
+                    Variable(
+                        value = listOf("At Hoboken, elevator from street to fare zone is"),
+                        variableName = "Station Elevator Description",
+                        isRequired = true,
+                        seq = 1
+                    ),
+                    Variable(
+                        value = listOf("temporarily out of service"),
+                        variableName = "Elevator Status",
+                        isRequired = true,
+                        seq = 2
+                    ),
+                    Variable(
+                        value = listOf("Call 800-234-PATH or use Passenger Assistance Phone if no agent is available."),
+                        variableName = "Elevator Guidance",
+                        isRequired = false,
+                        seq = 3
+                    ),
+                )
+            ),
+            createdDate = 1734988841776,
+            modifiedDate = 1734988841776
+        )
+        val NwkWtcDown = EverbridgeAlert(
+            incidentMessage = IncidentMessage(
+                subject = "PATHAlert Update: Track Condition",
+                preMessage = "01:56 PM: NWK-WTC delays continue. Next update w/in 15m.",
+                formVariableItems = listOf(
+                    Variable(
+                        value = listOf("NWK-WTC"),
+                        variableName = "Lines",
+                        isRequired = true,
+                        seq = 1
+                    ),
+                    Variable(
+                        value = listOf("delays continue."),
+                        variableName = "Status",
+                        isRequired = true,
+                        seq = 2
+                    ),
+                    Variable(
+                        value = listOf("Crew working to resolve track condition"),
+                        variableName = "Track Condition Reason Update",
+                        isRequired = false,
+                        seq = 3
+                    ),
+                    Variable(
+                        value = listOf("between"),
+                        variableName = "Preposition",
+                        isRequired = true,
+                        seq = 4
+                    ),
+                    Variable(
+                        value = listOf("HAR", "JSQ"),
+                        variableName = "Station",
+                        isRequired = true,
+                        seq = 5
+                    ),
+                    Variable(
+                        variableName = "NJT Cross Honor Status",
+                        isRequired = false,
+                        seq = 6
+                    ),
+                    Variable(
+                        variableName = "NJT Cross Honoring at",
+                        isRequired = false,
+                        seq = 7
+                    ),
+                    Variable(
+                        variableName = "NYWW Cross Honor Status",
+                        isRequired = false,
+                        seq = 8
+                    ),
+                    Variable(
+                        variableName = "NYWW Cross Honoring at",
+                        isRequired = false,
+                        seq = 9
+                    ),
+                    Variable(
+                        variableName = "Cross Honor Start/End Time",
+                        isRequired = false,
+                        seq = 10
+                    ),
+                    Variable(
+                        variableName = "Time Select",
+                        isRequired = false,
+                        seq = 11
+                    ),
+                    Variable(
+                        value = listOf("Next update w/in 15m."),
+                        variableName = "Guidance",
+                        isRequired = false,
+                        seq = 12
+                    )
+                )
+            ),
+            createdDate = 1729533384417,
+            modifiedDate = 1729533384417
+        )
+    }
+}


### PR DESCRIPTION
Half of #1.

Currently it just looks like this:

<img width="300" alt="Screenshot 2024-12-23 at 22 27 24" src="https://github.com/user-attachments/assets/bac47df9-28c5-4765-a321-3687767c2036" />

when the page looks like

<img width="1022" alt="Screenshot 2024-12-23 at 22 27 24" src="https://github.com/user-attachments/assets/3c670030-95da-4521-bd6b-a7b6e9192df2" />

~~There have not been line-specific alerts that I can test with at this moment; I'll update when time comes.~~ Line-specific alerts do work. Note that I have global alerts filtered by lines (that is, alerts about trains that are hidden by the user are not shown), but the filter might not work (seems like setting changes aren't immediately reflected?)

Some concerns:

* The app would only show 1 station alert. Now at this time there happens to be the same alert repeated twice in slightly different wording, but you might want to consider supporting multiple alerts for each station.
* The current logic might not handle weekend JSQ-33 via HOB service, I'll fix it when I see an alert