### PR TITLE
fix(api): parse weekend service in alerts

### DIFF
--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/Line.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/Line.kt
@@ -1,0 +1,7 @@
+package com.sixbynine.transit.path.api
+
+import com.sixbynine.transit.path.preferences.IntPersistable
+
+enum class Line(override val number: Int) : IntPersistable {
+    NewarkWtc(1), HobokenWtc(2), JournalSquare33rd(3), Hoboken33rd(4);
+}

--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
@@ -77,7 +77,7 @@ fun EverbridgeAlert.isForStation(station: Station): Boolean {
 fun EverbridgeAlert.isForLines(lineIds: List<Int>): Boolean {
     // this should match the order in Line.kt
     val linesDesc = incidentMessage.formVariableItems.firstOrNull { it.variableName == "Lines" }
-    return linesDesc?.value?.any { lineIds.contains(lineToIndex(it)) } ?: false
+    return linesDesc?.value?.any { lineIds.intersect(lineToIndex(it)).isNotEmpty() } ?: false
 }
 
 fun EverbridgeAlert.toGithubAlert(): Alert {
@@ -116,13 +116,14 @@ fun EverbridgeAlerts.getAlertsForLines(lineIds: List<Int>): List<Alert> {
     return data.filter { it.isForLines(lineIds) }.map { it.toGithubAlert() }
 }
 
-fun lineToIndex(line: String): Int {
-    when (line) {
-        // TODO: weekend services
-        "NWK-WTC" -> return 1
-        "HOB-WTC" -> return 2
-        "JSQ-33" -> return 3
-        "HOB-33" -> return 4
+fun lineToIndex(line: String): Set<Int> {
+    if (line == "JSQ-33 via HOB") return setOf(3, 4)
+    val x = when (line) {
+        "NWK-WTC" -> 1
+        "HOB-WTC" -> 2
+        "JSQ-33" -> 3
+        "HOB-33" -> 4
+        else -> null
     }
-    return 0
+    return if (x != null) setOf(x) else emptySet<Int>()
 }

--- a/api/src/commonTest/kotlin/com/sixbynine/transit/path/EverbridgeAlertsTest.kt
+++ b/api/src/commonTest/kotlin/com/sixbynine/transit/path/EverbridgeAlertsTest.kt
@@ -1,5 +1,7 @@
 package com.sixbynine.transit.path
 
+import com.sixbynine.transit.path.api.Line.HobokenWtc
+import com.sixbynine.transit.path.api.Line.NewarkWtc
 import com.sixbynine.transit.path.api.Stations
 import com.sixbynine.transit.path.api.alerts.AlertText
 import com.sixbynine.transit.path.api.alerts.isActiveAt
@@ -50,14 +52,14 @@ class EverbridgeAlertsTest {
     @Test
     fun `global alert conversion`() {
         val alerts = EverbridgeAlerts(NwkWtcDown)
-        val result = alerts.getAlertsForLines(listOf(1)).first()
+        val result = alerts.getAlertsForLines(listOf(NewarkWtc)).first()
         assertEquals(result.stations, emptyList())
         assertEquals(result.message, AlertText(NwkWtcDown.incidentMessage.preMessage))
         assertNull(result.trains.all)
         assertNull(result.trains.headSigns)
         assertTrue(result.isActiveAt(LocalDateTime(2024, OCTOBER, 21, 13, 57)))
         assertTrue(result.isGlobal)
-        assertTrue(alerts.getAlertsForLines(listOf(2)).isEmpty())
+        assertTrue(alerts.getAlertsForLines(listOf(HobokenWtc)).isEmpty())
     }
 
     private companion object {

--- a/composeApp/src/commonMain/kotlin/com/sixbynine/transit/path/api/LineExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/sixbynine/transit/path/api/LineExtensions.kt
@@ -7,13 +7,8 @@ import com.sixbynine.transit.path.api.Line.NewarkWtc
 import com.sixbynine.transit.path.app.ui.ColorWrapper
 import com.sixbynine.transit.path.app.ui.Colors
 import com.sixbynine.transit.path.app.ui.home.HomeScreenContract
-import com.sixbynine.transit.path.preferences.IntPersistable
 import com.sixbynine.transit.path.widget.WidgetData.SignData
 import com.sixbynine.transit.path.widget.WidgetData.TrainData
-
-enum class Line(override val number: Int) : IntPersistable {
-    NewarkWtc(1), HobokenWtc(2), JournalSquare33rd(3), Hoboken33rd(4);
-}
 
 val Line.colors: List<ColorWrapper>
     get() = when (this) {


### PR DESCRIPTION
Quickfix to handle weekend service in alerts. I don't think it's possible to move `Line` to `api` due to additional methods, but I've not looked deeply into Kotlin inheritance rules