### PR TITLE
feat: only show alerts of lines configured to be shown

### DIFF
--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/alerts/GithubAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/alerts/GithubAlerts.kt
@@ -1,5 +1,6 @@
 package com.sixbynine.transit.path.api.alerts
 
+import com.sixbynine.transit.path.api.Line
 import com.sixbynine.transit.path.api.Station
 import com.sixbynine.transit.path.time.NewYorkTimeZone
 import com.sixbynine.transit.path.time.now
@@ -34,6 +35,8 @@ data class Alert(
     val level: String? = null,
     /** Whether this is a global level alert. Stations are ignored if so. */
     val isGlobal: Boolean = false,
+    /** Lines affected. */
+    val lines: Set<Line>? = null,
 )
 
 fun Alert(
@@ -44,6 +47,7 @@ fun Alert(
     url: AlertText? = null,
     displaySchedule: Schedule? = null,
     level: String? = null,
+    lines: Set<Line>? = null
 ): Alert {
     return Alert(
         stations = stations.map { it.pathApiName },
@@ -53,6 +57,7 @@ fun Alert(
         message = message,
         url = url,
         level = level,
+        lines = lines,
     )
 }
 

--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
@@ -108,7 +108,8 @@ fun EverbridgeAlert.toGithubAlert(station: Station): Alert {
         ),
         trains = TrainFilter(),
         message = AlertText(incidentMessage.preMessage),
-        url = AlertText(PATH_ALERTS_URL)
+        url = AlertText(PATH_ALERTS_URL),
+        level = "INFO", // TODO: determine if it's about elevator or more serious
     )
 }
 

--- a/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
+++ b/api/src/commonMain/kotlin/com/sixbynine/transit/path/api/everbridge/EverbridgeAlerts.kt
@@ -94,7 +94,8 @@ fun EverbridgeAlert.toGithubAlert(): Alert {
         message = AlertText(incidentMessage.preMessage),
         url = AlertText(PATH_ALERTS_URL),
         isGlobal = true,
-        level = "WARN"
+        level = "WARN",
+        lines = incidentMessage.lines,
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/sixbynine/transit/path/app/ui/home/HomeScreenContract.kt
+++ b/composeApp/src/commonMain/kotlin/com/sixbynine/transit/path/app/ui/home/HomeScreenContract.kt
@@ -2,6 +2,7 @@ package com.sixbynine.transit.path.app.ui.home
 
 import androidx.compose.ui.unit.Dp
 import com.sixbynine.transit.path.api.BackfillSource
+import com.sixbynine.transit.path.api.Line
 import com.sixbynine.transit.path.api.Station
 import com.sixbynine.transit.path.api.StationSort
 import com.sixbynine.transit.path.api.state
@@ -77,6 +78,7 @@ object HomeScreenContract {
         val text: String,
         val url: String?,
         val isWarning: Boolean,
+        val lines: Set<Line>?,
     )
 
     sealed interface Intent {

--- a/composeApp/src/commonMain/kotlin/com/sixbynine/transit/path/app/ui/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/sixbynine/transit/path/app/ui/home/HomeScreenViewModel.kt
@@ -352,6 +352,10 @@ class HomeScreenViewModel(maxWidth: Dp, maxHeight: Dp) : PathViewModel<State, In
                                 )
                             }
                     )
+                },
+            globalAlerts = globalAlerts
+                .filter { alert ->
+                    SettingsManager.lineFilter.value.any { alert.lines?.contains(it) ?: false }
                 }
         )
     }
@@ -436,7 +440,8 @@ class HomeScreenViewModel(maxWidth: Dp, maxHeight: Dp) : PathViewModel<State, In
                     GlobalAlert(
                         text = it.message?.unpack() ?: return@mapNotNull null,
                         url = it.url?.unpack(),
-                        isWarning = it.isWarning
+                        isWarning = it.isWarning,
+                        lines = it.lines,
                     )
                 }
             )
@@ -454,7 +459,7 @@ class HomeScreenViewModel(maxWidth: Dp, maxHeight: Dp) : PathViewModel<State, In
                 if (isDelayed) append(localizedString(en = "Delayed - ", es = "Retrasado - "))
 
                 val time = when (timeDisplay) {
-                    TimeDisplay.Relative -> WidgetDataFormatter.formatRelativeTime(
+                    Relative -> WidgetDataFormatter.formatRelativeTime(
                         Clock.System.now(),
                         projectedArrival
                     )


### PR DESCRIPTION
UI-side changes. The point is that if one never rides on the midtown tube then they don't need to hear things about 33-HOB, so on so forth.

There's also a small commit that makes station alerts less urgent (because it's mostly elevators).

Of course a different approach would be to not convert `EverbridgeAlert` to `GithubAlert` and just use the former all the way, I just chose the route of least resistance...